### PR TITLE
Update release workflow to build darwin binaries and add triggers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,14 +2,22 @@ name: Release
 on:
   release:
     types: [created]
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 1 * *'
 
 jobs:
   release:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: ["amd64"]
-        os: ["linux"]
+        include:
+          - os: linux
+            arch: amd64
+          - os: darwin
+            arch: amd64
+          - os: darwin
+            arch: arm64
     steps:
       - name: Setup bazel
         uses: bazel-contrib/setup-bazel@0.15.0
@@ -18,7 +26,12 @@ jobs:
           disk-cache: ${{ github.workflow }}
           repository-cache: true
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+      - name: Derive version
+        id: version
+        run: |
+          VERSION=$(grep -m1 'version = ' MODULE.bazel | cut -d '"' -f 2)
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
       - name: "Test"
         run: "bazel test --test_output=errors //..."
       - name: "Build binaries for ${{ matrix.os }}_${{ matrix.arch }}"
@@ -30,4 +43,7 @@ jobs:
         with:
           allowUpdates: true
           artifacts: "bazel-bin/bazoekt-${{ matrix.os }}-${{ matrix.arch }}.zip"
+          tag: ${{ steps.version.outputs.version }}
+          name: ${{ steps.version.outputs.version }}
+          commit: ${{ github.sha }}
 


### PR DESCRIPTION
- Added `workflow_dispatch` and `schedule` (cron) triggers to the release workflow.
- Updated the release matrix to include macOS (darwin) amd64 and arm64 architectures alongside linux amd64.
- Added a step to dynamically derive the semantic version from `MODULE.bazel`.
- Configured the release action to use the derived version for the release tag and name.
- Upgraded the checkout action to v4.

---
*PR created automatically by Jules for task [3595578672083868243](https://jules.google.com/task/3595578672083868243) started by @filmil*