### PR TITLE
Update tag-and-release workflow to publish to registry

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -15,6 +15,8 @@ on:
 jobs:
   tag:
     runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.tag_version.outputs.new_tag }}
     steps:
       - name: Setup bazel
         uses: bazel-contrib/setup-bazel@0.15.0
@@ -102,3 +104,12 @@ jobs:
           allowUpdates: true
           artifacts: "bazel-bin/bazoekt-${{ matrix.os }}-${{ matrix.arch }}.zip"
           tag: ${{ steps.tag_version.outputs.previous_tag }}
+
+  # This workflow waits for binary artifacts to be published.
+  publish:
+    needs: tag
+    uses: ./.github/workflows/publish.yml
+    with:
+      tag_name: ${{ needs.tag.outputs.tag_name }}
+    secrets:
+      BCR_PUBLISH_TOKEN: ${{ secrets.BCR_PUBLISH_TOKEN }}


### PR DESCRIPTION
This change modifies the `.github/workflows/tag-and-release.yml` file to expose the generated tag from the `tag` job. It also adds a new `publish` job at the bottom of the workflow that uses the existing `.github/workflows/publish.yml` template to publish the release to the registry, bringing it to parity with the workflow in `filmil/futility`.

---
*PR created automatically by Jules for task [15764397895448714505](https://jules.google.com/task/15764397895448714505) started by @filmil*