### PR TITLE
fix: correct syntax error in MODULE.bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,7 +1,7 @@
 module(
     name = "bazoekt",
     version = "0.0.0",
-    bazel_compatibility = [">=9.0.0"].
+    bazel_compatibility = [">=9.0.0"],
 )
 
 bazel_dep(name = "rules_go", version = "0.60.0")


### PR DESCRIPTION
Fixes a syntax error in `MODULE.bazel` where a period was used instead of a comma. This caused a Bazel build failure.

---
*PR created automatically by Jules for task [2650884219403258879](https://jules.google.com/task/2650884219403258879) started by @filmil*