### PR TITLE
chore: upgrade bazel_dep versions

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,15 +4,15 @@ module(
     bazel_compatibility = [">=9.0.0"],
 )
 
-bazel_dep(name = "rules_go", version = "0.60.0")
-bazel_dep(name = "gazelle", version = "0.51.0")
-bazel_dep(name = "protobuf", version = "34.1")
+bazel_dep(name = "rules_go", version = "0.61.1")
+bazel_dep(name = "gazelle", version = "0.51.3")
+bazel_dep(name = "protobuf", version = "35.1")
 bazel_dep(name = "rules_pkg", version = "1.2.0")
-bazel_dep(name = "rules_python", version = "2.0.1")
-bazel_dep(name = "gotopt2", version = "2.3.3")
+bazel_dep(name = "rules_python", version = "2.0.2")
+bazel_dep(name = "gotopt2", version = "2.7.1")
 bazel_dep(name = "buildifier_prebuilt", version = "8.5.1.2")
 bazel_dep(name = "rules_shell", version = "0.8.0")
-bazel_dep(name = "rules_android", version = "0.7.2")
+bazel_dep(name = "rules_android", version = "0.7.3")
 
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.from_file(go_mod = "//:go.mod")


### PR DESCRIPTION
This PR upgrades bazel_dep versions in MODULE.bazel to the latest available in the BCR.

* rules_go: 0.60.0 -> 0.61.1
* gazelle: 0.51.0 -> 0.51.3
* protobuf: 34.1 -> 35.1
* rules_python: 2.0.1 -> 2.0.2
* gotopt2: 2.3.3 -> 2.7.1
* rules_android: 0.7.2 -> 0.7.3